### PR TITLE
Home nav fix 

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/dealseekerapplication/PrivacyPolicy.kt
+++ b/app/src/main/java/com/example/dealseekerapplication/PrivacyPolicy.kt
@@ -20,13 +20,6 @@ class PrivacyPolicy : Fragment(R.layout.fragment_privacypolicy) {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        binding.backButton.setOnClickListener {
-            parentFragmentManager.popBackStack()
-        }
-    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/example/dealseekerapplication/Profile.kt
+++ b/app/src/main/java/com/example/dealseekerapplication/Profile.kt
@@ -39,7 +39,7 @@ class Profile : Fragment(R.layout.fragment_profile) {
 
     private fun replaceFragment(fragment: Fragment) {
         parentFragmentManager.beginTransaction()
-            .replace(R.id.main, fragment)
+            .replace(R.id.frame_layout, fragment)
             .addToBackStack(null)
             .commit()
     }

--- a/app/src/main/java/com/example/dealseekerapplication/RequestSupport.kt
+++ b/app/src/main/java/com/example/dealseekerapplication/RequestSupport.kt
@@ -21,14 +21,6 @@ class RequestSupport : Fragment(R.layout.fragment_request_support) {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        binding.backButton.setOnClickListener {
-            parentFragmentManager.popBackStack()
-        }
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/app/src/main/java/com/example/dealseekerapplication/Settings.kt
+++ b/app/src/main/java/com/example/dealseekerapplication/Settings.kt
@@ -20,13 +20,6 @@ class Settings : Fragment(R.layout.fragment_settings) {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        binding.backButton.setOnClickListener {
-            parentFragmentManager.popBackStack()
-        }
-    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/res/layout/fragment_privacypolicy.xml
+++ b/app/src/main/res/layout/fragment_privacypolicy.xml
@@ -52,13 +52,6 @@
         />
     </ScrollView>
 
-    <Button
-        android:id="@+id/back_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Back"
-        android:layout_marginTop="650dp"/>
-
 </RelativeLayout>
 
 

--- a/app/src/main/res/layout/fragment_request_support.xml
+++ b/app/src/main/res/layout/fragment_request_support.xml
@@ -49,12 +49,4 @@
         android:text="Description"
         android:textColor="@color/white"/>
 
-    <Button
-        android:id="@+id/back_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Back"
-        android:layout_marginTop="650dp"/>
-
-
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -37,12 +37,5 @@
         android:text="change password"
         android:layout_marginTop="130dp"/>
 
-    <Button
-        android:id="@+id/back_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Back"
-        android:layout_marginTop="650dp"/>
-
 
 </RelativeLayout>


### PR DESCRIPTION
Had an issue where the bottom navigation would stop working when accessing the settings. privacy policy and support request fragments from the profile page. 

Fixed the code so that the bottom navigation is now accessible from everywhere in the app.

Previously used a back button to go back pages. This has been removed since the navigation is fixed.